### PR TITLE
fix setting initial time

### DIFF
--- a/plugin/timedatepicker-handler.ios.js
+++ b/plugin/timedatepicker-handler.ios.js
@@ -39,17 +39,19 @@ function init(mCallback, title, initialDate, doneText, cancelText, buttonColor) 
     }
     if (cancelText){
         _cancelText=cancelText;
-    } 
+    }
     mPickerManager = IQActionSheetPickerView.alloc().initWithTitleDoneTextCancelTextDelegate(_title, _doneText, _cancelText, _delegate);
-   
+    if (mPickerManager) {
+        _isInit = true;
+    }
+
     if (initialDate) {
-    mPickerManager.date = _toNativeDate(initialDate);  
+        mPickerManager.date = _toNativeDate(initialDate);
     }
     if(buttonColor){
         mPickerManager.buttonColor = buttonColor;
     }
-    if (mPickerManager) {
-        _isInit = true;
+    if (_isInit) {
         return true;
     }
     else {


### PR DESCRIPTION
I your current version it isn't possible to set the initial time on ios. The check if PickManager is initialized, done by _toNativeDate, fails because the _isInit flag is set after the date set. 

I didn't look at the TypeScript Version.