### PR TITLE
Fix Webpack issue that breaks with TypeScript

### DIFF
--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -4,7 +4,8 @@
         "module": "commonjs",
         "removeComments": true,
         "experimentalDecorators": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "noEmitHelpers": true
     },
     "files": [
       "timedatepicker-handler.android.ts",


### PR DESCRIPTION
Fix #9 removing `__extends()`