### PR TITLE
Update versioning for IQActionSheetPickerView Pod File

### DIFF
--- a/plugin/platforms/ios/Podfile
+++ b/plugin/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'IQActionSheetPickerView', '~>1.0'
+pod 'IQActionSheetPickerView', '~> 1.0'

--- a/plugin/platforms/ios/Podfile
+++ b/plugin/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'IQActionSheetPickerView', '1.0.4'
+pod 'IQActionSheetPickerView', '~>1.0'


### PR DESCRIPTION
Several versions of IQActionSheetPickerView have been released since 1.0.4 containing fixes for iOS 11.

Update the versioning scheme of the PodFile so that future patch releases are allowed.